### PR TITLE
Make sure integer values can also be included in 'where' clauses

### DIFF
--- a/lib/mixpannenkoek/query.rb
+++ b/lib/mixpannenkoek/query.rb
@@ -133,9 +133,9 @@ module Mixpannenkoek
 
       case value
       when Array
-        %Q((#{value.map { |val| %Q(properties["#{key}"] #{operator} "#{val}") }.join(" #{join} ")}))
+        %Q((#{value.map { |val| %Q(string(properties["#{key}"]) #{operator} "#{val}") }.join(" #{join} ")}))
       else
-        %Q(properties["#{key}"] #{operator} "#{value}")
+        %Q(string(properties["#{key}"]) #{operator} "#{value}")
       end
     end
 

--- a/spec/lib/mixpannenkoek/query_spec.rb
+++ b/spec/lib/mixpannenkoek/query_spec.rb
@@ -12,20 +12,20 @@ describe Mixpannenkoek::Base do
   describe '#where' do
     subject { Mixpannenkoek::TestQuery.where(date: date_range).where(subject_name: 'Subject ABC').request_parameters[1] }
     it 'sets :where' do
-      expect(subject).to include({ where: 'properties["subject_name"] == "Subject ABC"' })
+      expect(subject).to include({ where: 'string(properties["subject_name"]) == "Subject ABC"' })
     end
 
     context 'called twice' do
       subject { Mixpannenkoek::TestQuery.where(date: date_range).where(subject_name: 'Subject ABC').where(training_name: 'Training XYZ').request_parameters[1] }
       it 'sets multiple :where conditions' do
-        expect(subject).to include({ where: 'properties["subject_name"] == "Subject ABC" and properties["training_name"] == "Training XYZ"' })
+        expect(subject).to include({ where: 'string(properties["subject_name"]) == "Subject ABC" and string(properties["training_name"]) == "Training XYZ"' })
       end
     end
 
     context 'called with value: []' do
       subject { Mixpannenkoek::TestQuery.where(date: date_range).where(subject_name: ['Subject ABC', 'Subject XYZ']).request_parameters[1] }
       it 'sets multiple :where conditions' do
-        expect(subject).to include({ where: '(properties["subject_name"] == "Subject ABC" or properties["subject_name"] == "Subject XYZ")' })
+        expect(subject).to include({ where: '(string(properties["subject_name"]) == "Subject ABC" or string(properties["subject_name"]) == "Subject XYZ")' })
       end
     end
 
@@ -60,20 +60,20 @@ describe Mixpannenkoek::Base do
   describe '#where.not' do
     subject { Mixpannenkoek::TestQuery.where(date: date_range).where.not(subject_name: 'Subject ABC').request_parameters[1] }
     it 'sets :where' do
-      expect(subject).to include({ where: 'properties["subject_name"] != "Subject ABC"' })
+      expect(subject).to include({ where: 'string(properties["subject_name"]) != "Subject ABC"' })
     end
 
     context 'called twice' do
       subject { Mixpannenkoek::TestQuery.where(date: date_range).where.not(subject_name: 'Subject ABC').where.not(training_name: 'Training XYZ').request_parameters[1] }
       it 'sets multiple :where conditions' do
-        expect(subject).to include({ where: 'properties["subject_name"] != "Subject ABC" and properties["training_name"] != "Training XYZ"' })
+        expect(subject).to include({ where: 'string(properties["subject_name"]) != "Subject ABC" and string(properties["training_name"]) != "Training XYZ"' })
       end
     end
 
     context 'called with value: []' do
       subject { Mixpannenkoek::TestQuery.where(date: date_range).where.not(subject_name: ['Subject ABC', 'Subject XYZ']).request_parameters[1] }
       it 'sets multiple :where conditions' do
-        expect(subject).to include({ where: '(properties["subject_name"] != "Subject ABC" and properties["subject_name"] != "Subject XYZ")' })
+        expect(subject).to include({ where: '(string(properties["subject_name"]) != "Subject ABC" and string(properties["subject_name"]) != "Subject XYZ")' })
       end
     end
   end
@@ -151,7 +151,7 @@ describe Mixpannenkoek::Base do
 
     subject { Mixpannenkoek::DefaultScopeQuery.where(date: date_range).request_parameters[1] }
     it 'applies the default scope' do
-      expect(subject).to include({ where: 'properties["subject_name"] == "Subject XYZ"' })
+      expect(subject).to include({ where: 'string(properties["subject_name"]) == "Subject XYZ"' })
     end
   end
 end


### PR DESCRIPTION
This pull request adds code that makes sure we always cast the 'properties' part(s) of the where_clause to a string.

The problem was as follows. We had a method with code like this:

```
Segmentation::CompanyViews.set(unit: 'month').where(date: "2015-01-01".."2015-07-01").where(company_id: id)
```

where `Segmentation::CompanyViews` is a class with set event "Viewed Company Page". Important here is that we specify a `company_id`.

But the output always returned zero values, even though the Mixpanel interface clearly showed non-zero values. This is because the call to Mixpanel looks like `properties["company_id"] == "74"`, whereas it should be `string(properties["company_id"]) == "74"`.

(I did not remove the quotes around the integer, but instead to cast everything to a string, because I know from experience with Mixpanel is that this works best in most cases).
